### PR TITLE
クラス名、関数名などをVB命名規則に従って大文字から始まるように修正

### DIFF
--- a/InventoryManagementSystem/ClsInventoryAdapter.vb
+++ b/InventoryManagementSystem/ClsInventoryAdapter.vb
@@ -2,7 +2,7 @@
 Imports System.Transactions
 Imports Microsoft.Data.SqlClient
 
-Public Class clsInventoryAdapter
+Public Class ClsInventoryAdapter
 
     Private mConnectionStringBuilder As SqlConnectionStringBuilder
 

--- a/InventoryManagementSystem/FrmInventoryInput.Designer.vb
+++ b/InventoryManagementSystem/FrmInventoryInput.Designer.vb
@@ -1,9 +1,9 @@
-﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
-Partial Class frmInventoryInput
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()>
+Partial Class FrmInventoryInput
     Inherits System.Windows.Forms.Form
 
     'フォームがコンポーネントの一覧をクリーンアップするために dispose をオーバーライドします。
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Protected Overrides Sub Dispose(ByVal disposing As Boolean)
         Try
             If disposing AndAlso components IsNot Nothing Then
@@ -20,42 +20,42 @@ Partial Class frmInventoryInput
     'メモ: 以下のプロシージャは Windows フォーム デザイナーで必要です。
     'Windows フォーム デザイナーを使用して変更できます。  
     'コード エディターを使って変更しないでください。
-    <System.Diagnostics.DebuggerStepThrough()> _
+    <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
-        Dim resources As ComponentModel.ComponentResourceManager = New ComponentModel.ComponentResourceManager(GetType(frmInventoryInput))
+        Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(FrmInventoryInput))
         SplitContainer1 = New SplitContainer()
-        cmbInputType = New ComboBox()
-        numKingaku = New NumericUpDown()
-        numSuryou = New NumericUpDown()
+        CmbInputType = New ComboBox()
+        NumKingaku = New NumericUpDown()
+        NumSuryou = New NumericUpDown()
         Label7 = New Label()
-        dtpInputDate = New DateTimePicker()
+        DtpInputDate = New DateTimePicker()
         Label3 = New Label()
         Label5 = New Label()
         Label4 = New Label()
         Label6 = New Label()
         Label2 = New Label()
         Label1 = New Label()
-        txtTantou = New TextBox()
-        txtBikou = New TextBox()
-        txtTani = New TextBox()
-        txtHinmei = New TextBox()
-        btnAdd = New Button()
+        TxtTantou = New TextBox()
+        TxtBikou = New TextBox()
+        TxtTani = New TextBox()
+        TxtHinmei = New TextBox()
+        BtnAdd = New Button()
         Label8 = New Label()
         SplitContainer2 = New SplitContainer()
-        dgvInventory = New DataGridView()
-        btnRegist = New Button()
-        btnExit = New Button()
+        DgvInventory = New DataGridView()
+        BtnRegist = New Button()
+        BtnExit = New Button()
         CType(SplitContainer1, ComponentModel.ISupportInitialize).BeginInit()
         SplitContainer1.Panel1.SuspendLayout()
         SplitContainer1.Panel2.SuspendLayout()
         SplitContainer1.SuspendLayout()
-        CType(numKingaku, ComponentModel.ISupportInitialize).BeginInit()
-        CType(numSuryou, ComponentModel.ISupportInitialize).BeginInit()
+        CType(NumKingaku, ComponentModel.ISupportInitialize).BeginInit()
+        CType(NumSuryou, ComponentModel.ISupportInitialize).BeginInit()
         CType(SplitContainer2, ComponentModel.ISupportInitialize).BeginInit()
         SplitContainer2.Panel1.SuspendLayout()
         SplitContainer2.Panel2.SuspendLayout()
         SplitContainer2.SuspendLayout()
-        CType(dgvInventory, ComponentModel.ISupportInitialize).BeginInit()
+        CType(DgvInventory, ComponentModel.ISupportInitialize).BeginInit()
         SuspendLayout()
         ' 
         ' SplitContainer1
@@ -68,22 +68,22 @@ Partial Class frmInventoryInput
         ' 
         ' SplitContainer1.Panel1
         ' 
-        SplitContainer1.Panel1.Controls.Add(cmbInputType)
-        SplitContainer1.Panel1.Controls.Add(numKingaku)
-        SplitContainer1.Panel1.Controls.Add(numSuryou)
+        SplitContainer1.Panel1.Controls.Add(CmbInputType)
+        SplitContainer1.Panel1.Controls.Add(NumKingaku)
+        SplitContainer1.Panel1.Controls.Add(NumSuryou)
         SplitContainer1.Panel1.Controls.Add(Label7)
-        SplitContainer1.Panel1.Controls.Add(dtpInputDate)
+        SplitContainer1.Panel1.Controls.Add(DtpInputDate)
         SplitContainer1.Panel1.Controls.Add(Label3)
         SplitContainer1.Panel1.Controls.Add(Label5)
         SplitContainer1.Panel1.Controls.Add(Label4)
         SplitContainer1.Panel1.Controls.Add(Label6)
         SplitContainer1.Panel1.Controls.Add(Label2)
         SplitContainer1.Panel1.Controls.Add(Label1)
-        SplitContainer1.Panel1.Controls.Add(txtTantou)
-        SplitContainer1.Panel1.Controls.Add(txtBikou)
-        SplitContainer1.Panel1.Controls.Add(txtTani)
-        SplitContainer1.Panel1.Controls.Add(txtHinmei)
-        SplitContainer1.Panel1.Controls.Add(btnAdd)
+        SplitContainer1.Panel1.Controls.Add(TxtTantou)
+        SplitContainer1.Panel1.Controls.Add(TxtBikou)
+        SplitContainer1.Panel1.Controls.Add(TxtTani)
+        SplitContainer1.Panel1.Controls.Add(TxtHinmei)
+        SplitContainer1.Panel1.Controls.Add(BtnAdd)
         SplitContainer1.Panel1.Controls.Add(Label8)
         ' 
         ' SplitContainer1.Panel2
@@ -93,37 +93,37 @@ Partial Class frmInventoryInput
         SplitContainer1.SplitterDistance = 211
         SplitContainer1.TabIndex = 0
         ' 
-        ' cmbInputType
+        ' CmbInputType
         ' 
-        cmbInputType.DropDownStyle = ComboBoxStyle.DropDownList
-        cmbInputType.FlatStyle = FlatStyle.System
-        cmbInputType.FormattingEnabled = True
-        cmbInputType.Items.AddRange(New Object() {"入庫", "出庫"})
-        cmbInputType.Location = New Point(73, 41)
-        cmbInputType.Name = "cmbInputType"
-        cmbInputType.Size = New Size(121, 23)
-        cmbInputType.TabIndex = 5
+        CmbInputType.DropDownStyle = ComboBoxStyle.DropDownList
+        CmbInputType.FlatStyle = FlatStyle.System
+        CmbInputType.FormattingEnabled = True
+        CmbInputType.Items.AddRange(New Object() {"入庫", "出庫"})
+        CmbInputType.Location = New Point(73, 41)
+        CmbInputType.Name = "CmbInputType"
+        CmbInputType.Size = New Size(121, 23)
+        CmbInputType.TabIndex = 5
         ' 
-        ' numKingaku
+        ' NumKingaku
         ' 
-        numKingaku.Location = New Point(484, 70)
-        numKingaku.Maximum = New Decimal(New Integer() {999999999, 0, 0, 0})
-        numKingaku.Name = "numKingaku"
-        numKingaku.Size = New Size(86, 23)
-        numKingaku.TabIndex = 13
-        numKingaku.ThousandsSeparator = True
-        numKingaku.Value = New Decimal(New Integer() {999999999, 0, 0, 0})
+        NumKingaku.Location = New Point(484, 70)
+        NumKingaku.Maximum = New Decimal(New Integer() {999999999, 0, 0, 0})
+        NumKingaku.Name = "NumKingaku"
+        NumKingaku.Size = New Size(86, 23)
+        NumKingaku.TabIndex = 13
+        NumKingaku.ThousandsSeparator = True
+        NumKingaku.Value = New Decimal(New Integer() {999999999, 0, 0, 0})
         ' 
-        ' numSuryou
+        ' NumSuryou
         ' 
-        numSuryou.DecimalPlaces = 2
-        numSuryou.Location = New Point(220, 70)
-        numSuryou.Maximum = New Decimal(New Integer() {9999999, 0, 0, 131072})
-        numSuryou.Name = "numSuryou"
-        numSuryou.Size = New Size(70, 23)
-        numSuryou.TabIndex = 9
-        numSuryou.ThousandsSeparator = True
-        numSuryou.Value = New Decimal(New Integer() {999999, 0, 0, 131072})
+        NumSuryou.DecimalPlaces = 2
+        NumSuryou.Location = New Point(220, 70)
+        NumSuryou.Maximum = New Decimal(New Integer() {9999999, 0, 0, 131072})
+        NumSuryou.Name = "NumSuryou"
+        NumSuryou.Size = New Size(70, 23)
+        NumSuryou.TabIndex = 9
+        NumSuryou.ThousandsSeparator = True
+        NumSuryou.Value = New Decimal(New Integer() {999999, 0, 0, 131072})
         ' 
         ' Label7
         ' 
@@ -134,14 +134,14 @@ Partial Class frmInventoryInput
         Label7.TabIndex = 12
         Label7.Text = "金額"
         ' 
-        ' dtpInputDate
+        ' DtpInputDate
         ' 
-        dtpInputDate.CustomFormat = "yyyy/MM/dd hh:mm"
-        dtpInputDate.Format = DateTimePickerFormat.Custom
-        dtpInputDate.Location = New Point(250, 12)
-        dtpInputDate.Name = "dtpInputDate"
-        dtpInputDate.Size = New Size(132, 23)
-        dtpInputDate.TabIndex = 3
+        DtpInputDate.CustomFormat = "yyyy/MM/dd hh:mm"
+        DtpInputDate.Format = DateTimePickerFormat.Custom
+        DtpInputDate.Location = New Point(250, 12)
+        DtpInputDate.Name = "DtpInputDate"
+        DtpInputDate.Size = New Size(132, 23)
+        DtpInputDate.TabIndex = 3
         ' 
         ' Label3
         ' 
@@ -197,45 +197,45 @@ Partial Class frmInventoryInput
         Label1.TabIndex = 0
         Label1.Text = "担当者"
         ' 
-        ' txtTantou
+        ' TxtTantou
         ' 
-        txtTantou.Location = New Point(73, 12)
-        txtTantou.Name = "txtTantou"
-        txtTantou.Size = New Size(100, 23)
-        txtTantou.TabIndex = 1
+        TxtTantou.Location = New Point(73, 12)
+        TxtTantou.Name = "TxtTantou"
+        TxtTantou.Size = New Size(100, 23)
+        TxtTantou.TabIndex = 1
         ' 
-        ' txtBikou
+        ' TxtBikou
         ' 
-        txtBikou.Location = New Point(12, 118)
-        txtBikou.MaxLength = 512
-        txtBikou.Multiline = True
-        txtBikou.Name = "txtBikou"
-        txtBikou.Size = New Size(800, 88)
-        txtBikou.TabIndex = 15
-        txtBikou.Text = resources.GetString("txtBikou.Text")
+        TxtBikou.Location = New Point(12, 118)
+        TxtBikou.MaxLength = 512
+        TxtBikou.Multiline = True
+        TxtBikou.Name = "TxtBikou"
+        TxtBikou.Size = New Size(800, 88)
+        TxtBikou.TabIndex = 15
+        TxtBikou.Text = resources.GetString("TxtBikou.Text")
         ' 
-        ' txtTani
+        ' TxtTani
         ' 
-        txtTani.Location = New Point(337, 70)
-        txtTani.Name = "txtTani"
-        txtTani.Size = New Size(100, 23)
-        txtTani.TabIndex = 11
+        TxtTani.Location = New Point(337, 70)
+        TxtTani.Name = "TxtTani"
+        TxtTani.Size = New Size(100, 23)
+        TxtTani.TabIndex = 11
         ' 
-        ' txtHinmei
+        ' TxtHinmei
         ' 
-        txtHinmei.Location = New Point(73, 70)
-        txtHinmei.Name = "txtHinmei"
-        txtHinmei.Size = New Size(100, 23)
-        txtHinmei.TabIndex = 7
+        TxtHinmei.Location = New Point(73, 70)
+        TxtHinmei.Name = "TxtHinmei"
+        TxtHinmei.Size = New Size(100, 23)
+        TxtHinmei.TabIndex = 7
         ' 
-        ' btnAdd
+        ' BtnAdd
         ' 
-        btnAdd.Location = New Point(667, 76)
-        btnAdd.Name = "btnAdd"
-        btnAdd.Size = New Size(145, 36)
-        btnAdd.TabIndex = 16
-        btnAdd.Text = "追加"
-        btnAdd.UseVisualStyleBackColor = True
+        BtnAdd.Location = New Point(667, 76)
+        BtnAdd.Name = "BtnAdd"
+        BtnAdd.Size = New Size(145, 36)
+        BtnAdd.TabIndex = 16
+        BtnAdd.Text = "追加"
+        BtnAdd.UseVisualStyleBackColor = True
         ' 
         ' Label8
         ' 
@@ -256,91 +256,91 @@ Partial Class frmInventoryInput
         ' 
         ' SplitContainer2.Panel1
         ' 
-        SplitContainer2.Panel1.Controls.Add(dgvInventory)
+        SplitContainer2.Panel1.Controls.Add(DgvInventory)
         ' 
         ' SplitContainer2.Panel2
         ' 
-        SplitContainer2.Panel2.Controls.Add(btnRegist)
-        SplitContainer2.Panel2.Controls.Add(btnExit)
+        SplitContainer2.Panel2.Controls.Add(BtnRegist)
+        SplitContainer2.Panel2.Controls.Add(BtnExit)
         SplitContainer2.Panel2MinSize = 38
         SplitContainer2.Size = New Size(816, 397)
         SplitContainer2.SplitterDistance = 345
         SplitContainer2.TabIndex = 0
         ' 
-        ' dgvInventory
+        ' DgvInventory
         ' 
-        dgvInventory.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize
-        dgvInventory.Dock = DockStyle.Fill
-        dgvInventory.Location = New Point(0, 0)
-        dgvInventory.Name = "dgvInventory"
-        dgvInventory.ReadOnly = True
-        dgvInventory.RowTemplate.Height = 25
-        dgvInventory.Size = New Size(816, 345)
-        dgvInventory.TabIndex = 0
+        DgvInventory.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize
+        DgvInventory.Dock = DockStyle.Fill
+        DgvInventory.Location = New Point(0, 0)
+        DgvInventory.Name = "DgvInventory"
+        DgvInventory.ReadOnly = True
+        DgvInventory.RowTemplate.Height = 25
+        DgvInventory.Size = New Size(816, 345)
+        DgvInventory.TabIndex = 0
         ' 
-        ' btnRegist
+        ' BtnRegist
         ' 
-        btnRegist.Dock = DockStyle.Fill
-        btnRegist.Location = New Point(0, 0)
-        btnRegist.Name = "btnRegist"
-        btnRegist.Size = New Size(653, 48)
-        btnRegist.TabIndex = 0
-        btnRegist.Text = "登録"
-        btnRegist.UseVisualStyleBackColor = True
+        BtnRegist.Dock = DockStyle.Fill
+        BtnRegist.Location = New Point(0, 0)
+        BtnRegist.Name = "BtnRegist"
+        BtnRegist.Size = New Size(653, 48)
+        BtnRegist.TabIndex = 0
+        BtnRegist.Text = "登録"
+        BtnRegist.UseVisualStyleBackColor = True
         ' 
-        ' btnExit
+        ' BtnExit
         ' 
-        btnExit.Dock = DockStyle.Right
-        btnExit.Location = New Point(653, 0)
-        btnExit.Name = "btnExit"
-        btnExit.Size = New Size(163, 48)
-        btnExit.TabIndex = 1
-        btnExit.Text = "終了"
-        btnExit.UseVisualStyleBackColor = True
+        BtnExit.Dock = DockStyle.Right
+        BtnExit.Location = New Point(653, 0)
+        BtnExit.Name = "BtnExit"
+        BtnExit.Size = New Size(163, 48)
+        BtnExit.TabIndex = 1
+        BtnExit.Text = "終了"
+        BtnExit.UseVisualStyleBackColor = True
         ' 
-        ' frmInventoryInput
+        ' FrmInventoryInput
         ' 
         AutoScaleDimensions = New SizeF(7F, 15F)
         AutoScaleMode = AutoScaleMode.Font
         ClientSize = New Size(816, 612)
         Controls.Add(SplitContainer1)
-        Name = "frmInventoryInput"
-        Text = "frmInventoryInput"
+        Name = "FrmInventoryInput"
+        Text = "FrmInventoryInput"
         SplitContainer1.Panel1.ResumeLayout(False)
         SplitContainer1.Panel1.PerformLayout()
         SplitContainer1.Panel2.ResumeLayout(False)
         CType(SplitContainer1, ComponentModel.ISupportInitialize).EndInit()
         SplitContainer1.ResumeLayout(False)
-        CType(numKingaku, ComponentModel.ISupportInitialize).EndInit()
-        CType(numSuryou, ComponentModel.ISupportInitialize).EndInit()
+        CType(NumKingaku, ComponentModel.ISupportInitialize).EndInit()
+        CType(NumSuryou, ComponentModel.ISupportInitialize).EndInit()
         SplitContainer2.Panel1.ResumeLayout(False)
         SplitContainer2.Panel2.ResumeLayout(False)
         CType(SplitContainer2, ComponentModel.ISupportInitialize).EndInit()
         SplitContainer2.ResumeLayout(False)
-        CType(dgvInventory, ComponentModel.ISupportInitialize).EndInit()
+        CType(DgvInventory, ComponentModel.ISupportInitialize).EndInit()
         ResumeLayout(False)
     End Sub
 
     Friend WithEvents SplitContainer1 As SplitContainer
     Friend WithEvents SplitContainer2 As SplitContainer
-    Friend WithEvents btnExit As Button
-    Friend WithEvents btnRegist As Button
-    Friend WithEvents dgvInventory As DataGridView
+    Friend WithEvents BtnExit As Button
+    Friend WithEvents BtnRegist As Button
+    Friend WithEvents DgvInventory As DataGridView
     Friend WithEvents Label2 As Label
     Friend WithEvents Label1 As Label
-    Friend WithEvents txtHinmei As TextBox
-    Friend WithEvents btnAdd As Button
-    Friend WithEvents dtpInputDate As DateTimePicker
-    Friend WithEvents cmbInputType As ComboBox
-    Friend WithEvents numSuryou As NumericUpDown
+    Friend WithEvents TxtHinmei As TextBox
+    Friend WithEvents BtnAdd As Button
+    Friend WithEvents DtpInputDate As DateTimePicker
+    Friend WithEvents CmbInputType As ComboBox
+    Friend WithEvents NumSuryou As NumericUpDown
     Friend WithEvents Label3 As Label
     Friend WithEvents Label5 As Label
     Friend WithEvents Label4 As Label
-    Friend WithEvents txtTantou As TextBox
-    Friend WithEvents numKingaku As NumericUpDown
+    Friend WithEvents TxtTantou As TextBox
+    Friend WithEvents NumKingaku As NumericUpDown
     Friend WithEvents Label7 As Label
     Friend WithEvents Label8 As Label
     Friend WithEvents Label6 As Label
-    Friend WithEvents txtBikou As TextBox
-    Friend WithEvents txtTani As TextBox
+    Friend WithEvents TxtBikou As TextBox
+    Friend WithEvents TxtTani As TextBox
 End Class

--- a/InventoryManagementSystem/FrmInventoryInput.resx
+++ b/InventoryManagementSystem/FrmInventoryInput.resx
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
-    Microsoft ResX Schema 
+    Microsoft ResX Schema
 
     Version 2.0
 
@@ -48,7 +48,7 @@
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
@@ -117,28 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="vSyoriKubun.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="vHinmei.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="vSuuryou.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="vTani.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="vKingaku.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="vTantousya.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="vBikou.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="vSyoriDateTime.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
+  <data name="TxtBikou.Text" xml:space="preserve">
+    <value>0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
+0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
+0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
+0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
+0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
+</value>
+  </data>
 </root>

--- a/InventoryManagementSystem/FrmInventoryInput.vb
+++ b/InventoryManagementSystem/FrmInventoryInput.vb
@@ -1,7 +1,7 @@
 ﻿Imports System.ComponentModel
 Imports System.Text
 
-Public Class frmInventoryInput
+Public Class FrmInventoryInput
 
     ''' <summary>
     ''' 追加済データの登録／未登録
@@ -16,7 +16,7 @@ Public Class frmInventoryInput
     ''' <summary>
     ''' 在庫データ接続クラス
     ''' </summary>
-    Private fpInventoryAdapter As New clsInventoryAdapter
+    Private fpInventoryAdapter As New ClsInventoryAdapter
 
 
     ''' <summary>
@@ -24,7 +24,7 @@ Public Class frmInventoryInput
     ''' </summary>
     ''' <param name="sender"></param>
     ''' <param name="e"></param>
-    Private Sub frmInventoryInput_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+    Private Sub FrmInventoryInput_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         ' 画面全体のデータをクリア
         Me.ClearInput(True)
 
@@ -33,7 +33,7 @@ Public Class frmInventoryInput
         Me.fpInventoryDataTable = fpInventoryAdapter.FillInventoryLog()
 
         ' 在庫履歴データをとデータグリッドビューへ結びつける
-        Me.dgvInventory.DataSource = Me.fpInventoryDataTable
+        Me.DgvInventory.DataSource = Me.fpInventoryDataTable
 
 
     End Sub
@@ -43,7 +43,7 @@ Public Class frmInventoryInput
     ''' </summary>
     ''' <param name="sender"></param>
     ''' <param name="e"></param>
-    Private Sub frmInventoryInput_FormClosing(sender As Object, e As FormClosingEventArgs) Handles Me.FormClosing
+    Private Sub FrmInventoryInput_FormClosing(sender As Object, e As FormClosingEventArgs) Handles Me.FormClosing
 
     End Sub
 
@@ -52,23 +52,23 @@ Public Class frmInventoryInput
     ''' </summary>
     ''' <param name="sender"></param>
     ''' <param name="e"></param>
-    Private Sub btnAdd_Click(sender As Object, e As EventArgs) Handles btnAdd.Click
+    Private Sub BtnAdd_Click(sender As Object, e As EventArgs) Handles BtnAdd.Click
         '' 入力中のデータがグリッドへ追加可能か確認
         If (Me.ValidateData() = False) Then
-            Me.txtTantou.Focus()
+            Me.TxtTantou.Focus()
             Return
         End If
 
         '' 入力中のデータを行データとしてまとめる
         Dim wNewRow As DataRow = fpInventoryDataTable.NewRow()
-        wNewRow.Item("SyoriKubun") = {"1", "2"}(Me.cmbInputType.SelectedIndex)
-        wNewRow.Item("Hinmei") = Me.txtHinmei.Text.ToString()
-        wNewRow.Item("Suuryou") = CInt(Me.numSuryou.Value)
-        wNewRow.Item("Tani") = Me.txtTani.Text
-        wNewRow.Item("Kingaku") = CInt(Me.numKingaku.Value)
-        wNewRow.Item("Tantousya") = Me.txtTantou.Text
-        wNewRow.Item("Bikou") = Me.txtBikou.Text
-        wNewRow.Item("SyoriDateTime") = Me.dtpInputDate.Value
+        wNewRow.Item("SyoriKubun") = {"1", "2"}(Me.CmbInputType.SelectedIndex)
+        wNewRow.Item("Hinmei") = Me.TxtHinmei.Text.ToString()
+        wNewRow.Item("Suuryou") = CInt(Me.NumSuryou.Value)
+        wNewRow.Item("Tani") = Me.TxtTani.Text
+        wNewRow.Item("Kingaku") = CInt(Me.NumKingaku.Value)
+        wNewRow.Item("Tantousya") = Me.TxtTantou.Text
+        wNewRow.Item("Bikou") = Me.TxtBikou.Text
+        wNewRow.Item("SyoriDateTime") = Me.DtpInputDate.Value
         wNewRow.Item("InputDateTime") = DateTime.MinValue
         wNewRow.Item("UpdateDateTime") = DateTime.MinValue
 
@@ -77,7 +77,7 @@ Public Class frmInventoryInput
 
         '' 画面を新規入力可能な状態に設定する
         Me.ClearInput(False)
-        Me.txtHinmei.Focus()
+        Me.TxtHinmei.Focus()
     End Sub
 
     ''' <summary>
@@ -85,7 +85,7 @@ Public Class frmInventoryInput
     ''' </summary>
     ''' <param name="sender"></param>
     ''' <param name="e"></param>
-    Private Sub btnRegist_Click(sender As Object, e As EventArgs) Handles btnRegist.Click
+    Private Sub BtnRegist_Click(sender As Object, e As EventArgs) Handles BtnRegist.Click
         ' DBを更新し最新データを再度取得する
         If (fpInventoryAdapter.InsertInventoryLog(fpInventoryDataTable) > 0) Then
 
@@ -93,7 +93,7 @@ Public Class frmInventoryInput
             Me.fpInventoryDataTable = fpInventoryAdapter.FillInventoryLog()
 
             ' 在庫履歴データをとデータグリッドビューへ結びつける
-            Me.dgvInventory.DataSource = Me.fpInventoryDataTable
+            Me.DgvInventory.DataSource = Me.fpInventoryDataTable
         End If
 
     End Sub
@@ -103,7 +103,7 @@ Public Class frmInventoryInput
     ''' </summary>
     ''' <param name="sender"></param>
     ''' <param name="e"></param>
-    Private Sub btnExit_Click(sender As Object, e As EventArgs) Handles btnExit.Click
+    Private Sub BtnExit_Click(sender As Object, e As EventArgs) Handles BtnExit.Click
         Me.Close()
     End Sub
 
@@ -114,16 +114,16 @@ Public Class frmInventoryInput
     Private Sub ClearInput(ByVal aNewForm As Boolean)
         If (aNewForm) Then
             '' フォーム立ち上げ時のみクリアする項目
-            Me.txtTantou.Clear()
+            Me.TxtTantou.Clear()
 
         End If
 
-        Me.cmbInputType.SelectedIndex = 0
-        Me.txtHinmei.Clear()
-        Me.numSuryou.Value = 0
-        Me.numKingaku.Value = 0
-        Me.txtTani.Clear()
-        Me.txtBikou.Clear()
+        Me.CmbInputType.SelectedIndex = 0
+        Me.TxtHinmei.Clear()
+        Me.NumSuryou.Value = 0
+        Me.NumKingaku.Value = 0
+        Me.TxtTani.Clear()
+        Me.TxtBikou.Clear()
 
     End Sub
 
@@ -137,13 +137,13 @@ Public Class frmInventoryInput
         Dim wIsWarning As Boolean = False
 
         '' 各入力項目の警告メッセージと警告の有無を設定する
-        If (Me.txtTantou.Text.Trim.Length = 0) Then
+        If (Me.TxtTantou.Text.Trim.Length = 0) Then
             wSblWarningMessage.Append("・担当者が入力されていません" & vbCrLf)
             wIsWarning = True
 
         End If
 
-        If (Me.txtHinmei.Text.Trim.Length = 0) Then
+        If (Me.TxtHinmei.Text.Trim.Length = 0) Then
             wSblWarningMessage.Append("・品名が入力されていません" & vbCrLf)
             wIsWarning = True
 

--- a/InventoryManagementSystem/FrmInventoryViewer.Designer.vb
+++ b/InventoryManagementSystem/FrmInventoryViewer.Designer.vb
@@ -1,5 +1,5 @@
 ﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()>
-Partial Class frmInventoryViewer
+Partial Class FrmInventoryViewer
     Inherits System.Windows.Forms.Form
 
     'フォームがコンポーネントの一覧をクリーンアップするために dispose をオーバーライドします。
@@ -23,19 +23,19 @@ Partial Class frmInventoryViewer
     <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         SplitContainer1 = New SplitContainer()
-        cmbInputType = New ComboBox()
-        dtpInputDate = New DateTimePicker()
+        CmbInputType = New ComboBox()
+        DtpInputDate = New DateTimePicker()
         Label5 = New Label()
         Label4 = New Label()
         Label8 = New Label()
         Label2 = New Label()
         Label1 = New Label()
-        txtTantou = New TextBox()
-        txtBikou = New TextBox()
-        txtHinmei = New TextBox()
-        btnFind = New Button()
+        TxtTantou = New TextBox()
+        TxtBikou = New TextBox()
+        TxtHinmei = New TextBox()
+        BtnFind = New Button()
         SplitContainer2 = New SplitContainer()
-        dgvInventory = New DataGridView()
+        DgvInventory = New DataGridView()
         vSyoriKubun = New DataGridViewTextBoxColumn()
         vHinmei = New DataGridViewTextBoxColumn()
         vSuuryou = New DataGridViewTextBoxColumn()
@@ -44,7 +44,7 @@ Partial Class frmInventoryViewer
         vTantousya = New DataGridViewTextBoxColumn()
         vBikou = New DataGridViewTextBoxColumn()
         vSyoriDateTime = New DataGridViewTextBoxColumn()
-        btnExit = New Button()
+        BtnExit = New Button()
         CType(SplitContainer1, ComponentModel.ISupportInitialize).BeginInit()
         SplitContainer1.Panel1.SuspendLayout()
         SplitContainer1.Panel2.SuspendLayout()
@@ -53,7 +53,7 @@ Partial Class frmInventoryViewer
         SplitContainer2.Panel1.SuspendLayout()
         SplitContainer2.Panel2.SuspendLayout()
         SplitContainer2.SuspendLayout()
-        CType(dgvInventory, ComponentModel.ISupportInitialize).BeginInit()
+        CType(DgvInventory, ComponentModel.ISupportInitialize).BeginInit()
         SuspendLayout()
         ' 
         ' SplitContainer1
@@ -66,17 +66,17 @@ Partial Class frmInventoryViewer
         ' 
         ' SplitContainer1.Panel1
         ' 
-        SplitContainer1.Panel1.Controls.Add(cmbInputType)
-        SplitContainer1.Panel1.Controls.Add(dtpInputDate)
+        SplitContainer1.Panel1.Controls.Add(CmbInputType)
+        SplitContainer1.Panel1.Controls.Add(DtpInputDate)
         SplitContainer1.Panel1.Controls.Add(Label5)
         SplitContainer1.Panel1.Controls.Add(Label4)
         SplitContainer1.Panel1.Controls.Add(Label8)
         SplitContainer1.Panel1.Controls.Add(Label2)
         SplitContainer1.Panel1.Controls.Add(Label1)
-        SplitContainer1.Panel1.Controls.Add(txtTantou)
-        SplitContainer1.Panel1.Controls.Add(txtBikou)
-        SplitContainer1.Panel1.Controls.Add(txtHinmei)
-        SplitContainer1.Panel1.Controls.Add(btnFind)
+        SplitContainer1.Panel1.Controls.Add(TxtTantou)
+        SplitContainer1.Panel1.Controls.Add(TxtBikou)
+        SplitContainer1.Panel1.Controls.Add(TxtHinmei)
+        SplitContainer1.Panel1.Controls.Add(BtnFind)
         ' 
         ' SplitContainer1.Panel2
         ' 
@@ -85,26 +85,26 @@ Partial Class frmInventoryViewer
         SplitContainer1.SplitterDistance = 71
         SplitContainer1.TabIndex = 0
         ' 
-        ' cmbInputType
+        ' CmbInputType
         ' 
-        cmbInputType.DisplayMember = "1,2"
-        cmbInputType.DropDownStyle = ComboBoxStyle.DropDownList
-        cmbInputType.FlatStyle = FlatStyle.System
-        cmbInputType.FormattingEnabled = True
-        cmbInputType.Items.AddRange(New Object() {"入庫", "出庫"})
-        cmbInputType.Location = New Point(67, 41)
-        cmbInputType.Name = "cmbInputType"
-        cmbInputType.Size = New Size(121, 23)
-        cmbInputType.TabIndex = 5
-        cmbInputType.ValueMember = "1,2"
+        CmbInputType.DisplayMember = "1,2"
+        CmbInputType.DropDownStyle = ComboBoxStyle.DropDownList
+        CmbInputType.FlatStyle = FlatStyle.System
+        CmbInputType.FormattingEnabled = True
+        CmbInputType.Items.AddRange(New Object() {"入庫", "出庫"})
+        CmbInputType.Location = New Point(67, 41)
+        CmbInputType.Name = "CmbInputType"
+        CmbInputType.Size = New Size(121, 23)
+        CmbInputType.TabIndex = 5
+        CmbInputType.ValueMember = "1,2"
         ' 
-        ' dtpInputDate
+        ' DtpInputDate
         ' 
-        dtpInputDate.Format = DateTimePickerFormat.Short
-        dtpInputDate.Location = New Point(243, 12)
-        dtpInputDate.Name = "dtpInputDate"
-        dtpInputDate.Size = New Size(100, 23)
-        dtpInputDate.TabIndex = 3
+        DtpInputDate.Format = DateTimePickerFormat.Short
+        DtpInputDate.Location = New Point(243, 12)
+        DtpInputDate.Name = "DtpInputDate"
+        DtpInputDate.Size = New Size(100, 23)
+        DtpInputDate.TabIndex = 3
         ' 
         ' Label5
         ' 
@@ -151,35 +151,35 @@ Partial Class frmInventoryViewer
         Label1.TabIndex = 0
         Label1.Text = "担当者"
         ' 
-        ' txtTantou
+        ' TxtTantou
         ' 
-        txtTantou.Location = New Point(67, 12)
-        txtTantou.Name = "txtTantou"
-        txtTantou.Size = New Size(100, 23)
-        txtTantou.TabIndex = 1
+        TxtTantou.Location = New Point(67, 12)
+        TxtTantou.Name = "TxtTantou"
+        TxtTantou.Size = New Size(100, 23)
+        TxtTantou.TabIndex = 1
         ' 
-        ' txtBikou
+        ' TxtBikou
         ' 
-        txtBikou.Location = New Point(489, 41)
-        txtBikou.Name = "txtBikou"
-        txtBikou.Size = New Size(199, 23)
-        txtBikou.TabIndex = 9
+        TxtBikou.Location = New Point(489, 41)
+        TxtBikou.Name = "TxtBikou"
+        TxtBikou.Size = New Size(199, 23)
+        TxtBikou.TabIndex = 9
         ' 
-        ' txtHinmei
+        ' TxtHinmei
         ' 
-        txtHinmei.Location = New Point(243, 41)
-        txtHinmei.Name = "txtHinmei"
-        txtHinmei.Size = New Size(199, 23)
-        txtHinmei.TabIndex = 7
+        TxtHinmei.Location = New Point(243, 41)
+        TxtHinmei.Name = "TxtHinmei"
+        TxtHinmei.Size = New Size(199, 23)
+        TxtHinmei.TabIndex = 7
         ' 
-        ' btnFind
+        ' BtnFind
         ' 
-        btnFind.Location = New Point(699, 32)
-        btnFind.Name = "btnFind"
-        btnFind.Size = New Size(145, 36)
-        btnFind.TabIndex = 10
-        btnFind.Text = "検索"
-        btnFind.UseVisualStyleBackColor = True
+        BtnFind.Location = New Point(699, 32)
+        BtnFind.Name = "BtnFind"
+        BtnFind.Size = New Size(145, 36)
+        BtnFind.TabIndex = 10
+        BtnFind.Text = "検索"
+        BtnFind.UseVisualStyleBackColor = True
         ' 
         ' SplitContainer2
         ' 
@@ -191,27 +191,27 @@ Partial Class frmInventoryViewer
         ' 
         ' SplitContainer2.Panel1
         ' 
-        SplitContainer2.Panel1.Controls.Add(dgvInventory)
+        SplitContainer2.Panel1.Controls.Add(DgvInventory)
         ' 
         ' SplitContainer2.Panel2
         ' 
-        SplitContainer2.Panel2.Controls.Add(btnExit)
+        SplitContainer2.Panel2.Controls.Add(BtnExit)
         SplitContainer2.Panel2MinSize = 38
         SplitContainer2.Size = New Size(847, 537)
         SplitContainer2.SplitterDistance = 485
         SplitContainer2.TabIndex = 0
         ' 
-        ' dgvInventory
+        ' DgvInventory
         ' 
-        dgvInventory.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize
-        dgvInventory.Columns.AddRange(New DataGridViewColumn() {vSyoriKubun, vHinmei, vSuuryou, vTani, vKingaku, vTantousya, vBikou, vSyoriDateTime})
-        dgvInventory.Dock = DockStyle.Fill
-        dgvInventory.Location = New Point(0, 0)
-        dgvInventory.Name = "dgvInventory"
-        dgvInventory.ReadOnly = True
-        dgvInventory.RowTemplate.Height = 25
-        dgvInventory.Size = New Size(847, 485)
-        dgvInventory.TabIndex = 0
+        DgvInventory.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize
+        DgvInventory.Columns.AddRange(New DataGridViewColumn() {vSyoriKubun, vHinmei, vSuuryou, vTani, vKingaku, vTantousya, vBikou, vSyoriDateTime})
+        DgvInventory.Dock = DockStyle.Fill
+        DgvInventory.Location = New Point(0, 0)
+        DgvInventory.Name = "DgvInventory"
+        DgvInventory.ReadOnly = True
+        DgvInventory.RowTemplate.Height = 25
+        DgvInventory.Size = New Size(847, 485)
+        DgvInventory.TabIndex = 0
         ' 
         ' vSyoriKubun
         ' 
@@ -261,23 +261,23 @@ Partial Class frmInventoryViewer
         vSyoriDateTime.Name = "vSyoriDateTime"
         vSyoriDateTime.ReadOnly = True
         ' 
-        ' btnExit
+        ' BtnExit
         ' 
-        btnExit.Dock = DockStyle.Fill
-        btnExit.Location = New Point(0, 0)
-        btnExit.Name = "btnExit"
-        btnExit.Size = New Size(847, 48)
-        btnExit.TabIndex = 1
-        btnExit.Text = "終了"
-        btnExit.UseVisualStyleBackColor = True
+        BtnExit.Dock = DockStyle.Fill
+        BtnExit.Location = New Point(0, 0)
+        BtnExit.Name = "BtnExit"
+        BtnExit.Size = New Size(847, 48)
+        BtnExit.TabIndex = 1
+        BtnExit.Text = "終了"
+        BtnExit.UseVisualStyleBackColor = True
         ' 
-        ' frmInventoryViewer
+        ' FrmInventoryViewer
         ' 
         AutoScaleDimensions = New SizeF(7F, 15F)
         AutoScaleMode = AutoScaleMode.Font
         ClientSize = New Size(847, 612)
         Controls.Add(SplitContainer1)
-        Name = "frmInventoryViewer"
+        Name = "FrmInventoryViewer"
         Text = "在庫確認画面"
         SplitContainer1.Panel1.ResumeLayout(False)
         SplitContainer1.Panel1.PerformLayout()
@@ -288,25 +288,25 @@ Partial Class frmInventoryViewer
         SplitContainer2.Panel2.ResumeLayout(False)
         CType(SplitContainer2, ComponentModel.ISupportInitialize).EndInit()
         SplitContainer2.ResumeLayout(False)
-        CType(dgvInventory, ComponentModel.ISupportInitialize).EndInit()
+        CType(DgvInventory, ComponentModel.ISupportInitialize).EndInit()
         ResumeLayout(False)
     End Sub
 
     Friend WithEvents SplitContainer1 As SplitContainer
     Friend WithEvents SplitContainer2 As SplitContainer
-    Friend WithEvents btnExit As Button
-    Friend WithEvents dgvInventory As DataGridView
+    Friend WithEvents BtnExit As Button
+    Friend WithEvents DgvInventory As DataGridView
     Friend WithEvents Label2 As Label
     Friend WithEvents Label1 As Label
-    Friend WithEvents txtHinmei As TextBox
-    Friend WithEvents btnFind As Button
-    Friend WithEvents dtpInputDate As DateTimePicker
-    Friend WithEvents cmbInputType As ComboBox
+    Friend WithEvents TxtHinmei As TextBox
+    Friend WithEvents BtnFind As Button
+    Friend WithEvents DtpInputDate As DateTimePicker
+    Friend WithEvents CmbInputType As ComboBox
     Friend WithEvents Label5 As Label
     Friend WithEvents Label4 As Label
-    Friend WithEvents txtTantou As TextBox
+    Friend WithEvents TxtTantou As TextBox
     Friend WithEvents Label8 As Label
-    Friend WithEvents txtBikou As TextBox
+    Friend WithEvents TxtBikou As TextBox
     Friend WithEvents vSyoriKubun As DataGridViewTextBoxColumn
     Friend WithEvents vHinmei As DataGridViewTextBoxColumn
     Friend WithEvents vSuuryou As DataGridViewTextBoxColumn

--- a/InventoryManagementSystem/FrmInventoryViewer.resx
+++ b/InventoryManagementSystem/FrmInventoryViewer.resx
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
-    Microsoft ResX Schema 
+    Microsoft ResX Schema
 
     Version 2.0
 
@@ -48,7 +48,7 @@
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
@@ -117,12 +117,52 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="txtBikou.Text" xml:space="preserve">
-    <value>0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
-0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
-0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
-0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
-0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
-</value>
-  </data>
+  <metadata name="vSyoriKubun.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="vHinmei.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="vSuuryou.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="vTani.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="vKingaku.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="vTantousya.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="vBikou.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="vSyoriDateTime.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="vSyoriKubun.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="vHinmei.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="vSuuryou.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="vTani.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="vKingaku.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="vTantousya.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="vBikou.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="vSyoriDateTime.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
 </root>

--- a/InventoryManagementSystem/FrmInventoryViewer.vb
+++ b/InventoryManagementSystem/FrmInventoryViewer.vb
@@ -1,4 +1,4 @@
-﻿Public Class frmInventoryViewer
+﻿Public Class FrmInventoryViewer
 
     ''' <summary>
     ''' 追加済データの登録／未登録
@@ -13,7 +13,7 @@
     ''' <summary>
     ''' 在庫データ接続クラス
     ''' </summary>
-    Private fpInventoryAdapter As New clsInventoryAdapter
+    Private fpInventoryAdapter As New ClsInventoryAdapter
 
     ''' <summary>
     ''' データグリッドビュー上の列インデックス
@@ -36,7 +36,7 @@
     ''' </summary>
     ''' <param name="sender"></param>
     ''' <param name="e"></param>
-    Private Sub frmInventoryInput_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+    Private Sub FrmInventoryInput_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         ' 検索条件をリセットする
         Me.ClearInput()
 
@@ -48,7 +48,7 @@
     ''' </summary>
     ''' <param name="sender"></param>
     ''' <param name="e"></param>
-    Private Sub btnFind_Click(sender As Object, e As EventArgs) Handles btnFind.Click
+    Private Sub BtnFind_Click(sender As Object, e As EventArgs) Handles BtnFind.Click
         ' DBより最新の在庫データを取り込む
         Me.fpInventoryDataTable = fpInventoryAdapter.FillInventoryLog()
 
@@ -58,27 +58,27 @@
             (From
                  _dataRow In Me.fpInventoryDataTable
              Where
-                 _dataRow.Field(Of String)("Tantousya") = Me.txtTantou.Text.Trim And
-                 _dataRow.Field(Of DateTime)("SyoriDateTime").Date = Me.dtpInputDate.Value.Date And
-                 _dataRow.Field(Of String)("SyoriKubun") = {"1", "2"}(Me.cmbInputType.SelectedIndex))
+                 _dataRow.Field(Of String)("Tantousya") = Me.TxtTantou.Text.Trim And
+                 _dataRow.Field(Of DateTime)("SyoriDateTime").Date = Me.DtpInputDate.Value.Date And
+                 _dataRow.Field(Of String)("SyoriKubun") = {"1", "2"}(Me.CmbInputType.SelectedIndex))
 
         '' 検索結果を画面へ表示する
         Dim wRowCount As Integer = wViewDataRows.Count
-        Me.dgvInventory.RowCount = wRowCount ' データグリッドの行数を設定
+        Me.DgvInventory.RowCount = wRowCount ' データグリッドの行数を設定
 
         For _dtIdx As Integer = 0 To wRowCount - 1
             Dim wDataRow As DataRow = wViewDataRows(_dtIdx)
 
             '' 在庫データを成型してグリッドへ設定する
-            Me.dgvInventory.Item(InvGridColumns.vSyoriKubun, _dtIdx).Value =
+            Me.DgvInventory.Item(InvGridColumns.vSyoriKubun, _dtIdx).Value =
                 If(wDataRow.Field(Of String)("SyoriKubun") = "1", "入庫", "出庫")
-            Me.dgvInventory.Item(InvGridColumns.vHinmei, _dtIdx).Value = wDataRow.Field(Of String)("Hinmei")
-            Me.dgvInventory.Item(InvGridColumns.vSuuryou, _dtIdx).Value = wDataRow.Field(Of Integer)("Suuryou")
-            Me.dgvInventory.Item(InvGridColumns.vTani, _dtIdx).Value = wDataRow.Field(Of String)("Tani")
-            Me.dgvInventory.Item(InvGridColumns.vKingaku, _dtIdx).Value = wDataRow.Field(Of Integer)("Kingaku")
-            Me.dgvInventory.Item(InvGridColumns.vTantousya, _dtIdx).Value = wDataRow.Field(Of String)("Tantousya")
-            Me.dgvInventory.Item(InvGridColumns.vBikou, _dtIdx).Value = wDataRow.Field(Of String)("Bikou")
-            Me.dgvInventory.Item(InvGridColumns.vSyoriDateTime, _dtIdx).Value = wDataRow.Field(Of DateTime)("SyoriDatetime").ToString("yy/MM/dd HH:mm")
+            Me.DgvInventory.Item(InvGridColumns.vHinmei, _dtIdx).Value = wDataRow.Field(Of String)("Hinmei")
+            Me.DgvInventory.Item(InvGridColumns.vSuuryou, _dtIdx).Value = wDataRow.Field(Of Integer)("Suuryou")
+            Me.DgvInventory.Item(InvGridColumns.vTani, _dtIdx).Value = wDataRow.Field(Of String)("Tani")
+            Me.DgvInventory.Item(InvGridColumns.vKingaku, _dtIdx).Value = wDataRow.Field(Of Integer)("Kingaku")
+            Me.DgvInventory.Item(InvGridColumns.vTantousya, _dtIdx).Value = wDataRow.Field(Of String)("Tantousya")
+            Me.DgvInventory.Item(InvGridColumns.vBikou, _dtIdx).Value = wDataRow.Field(Of String)("Bikou")
+            Me.DgvInventory.Item(InvGridColumns.vSyoriDateTime, _dtIdx).Value = wDataRow.Field(Of DateTime)("SyoriDatetime").ToString("yy/MM/dd HH:mm")
 
         Next
 
@@ -90,7 +90,7 @@
     ''' </summary>
     ''' <param name="sender"></param>
     ''' <param name="e"></param>
-    Private Sub btnExit_Click(sender As Object, e As EventArgs) Handles btnExit.Click
+    Private Sub BtnExit_Click(sender As Object, e As EventArgs) Handles BtnExit.Click
         Me.Close()
 
     End Sub
@@ -100,10 +100,10 @@
     ''' 入力データのクリア
     ''' </summary>
     Private Sub ClearInput()
-        Me.txtTantou.Clear()
-        Me.cmbInputType.SelectedIndex = 0
-        Me.txtHinmei.Clear()
-        Me.txtBikou.Clear()
+        Me.TxtTantou.Clear()
+        Me.CmbInputType.SelectedIndex = 0
+        Me.TxtHinmei.Clear()
+        Me.TxtBikou.Clear()
     End Sub
 
 End Class

--- a/InventoryManagementSystem/FrmMenu.Designer.vb
+++ b/InventoryManagementSystem/FrmMenu.Designer.vb
@@ -1,5 +1,5 @@
 ﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
-Partial Class frmMenu
+Partial Class FrmMenu
     Inherits System.Windows.Forms.Form
 
     'フォームがコンポーネントの一覧をクリーンアップするために dispose をオーバーライドします。
@@ -63,7 +63,7 @@ Partial Class frmMenu
         Button3.Text = "終了"
         Button3.UseVisualStyleBackColor = False
         ' 
-        ' frmMenu
+        ' FrmMenu
         ' 
         AutoScaleDimensions = New SizeF(7F, 15F)
         AutoScaleMode = AutoScaleMode.Font
@@ -73,7 +73,7 @@ Partial Class frmMenu
         Controls.Add(Button3)
         Controls.Add(Button2)
         Controls.Add(Button1)
-        Name = "frmMenu"
+        Name = "FrmMenu"
         Text = "在庫管理システムーメニュー"
         ResumeLayout(False)
     End Sub

--- a/InventoryManagementSystem/FrmMenu.resx
+++ b/InventoryManagementSystem/FrmMenu.resx
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
-    Microsoft ResX Schema 
+    Microsoft ResX Schema
 
     Version 2.0
 
@@ -48,7 +48,7 @@
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter

--- a/InventoryManagementSystem/FrmMenu.vb
+++ b/InventoryManagementSystem/FrmMenu.vb
@@ -1,12 +1,12 @@
-﻿Public Class frmMenu
-    Private Sub frmMenu_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+﻿Public Class FrmMenu
+    Private Sub FrmMenu_Load(sender As Object, e As EventArgs) Handles MyBase.Load
 
     End Sub
 
     Private Sub Button1_Click(sender As Object, e As EventArgs) Handles Button1.Click
         Me.Enabled = False
 
-        frmInventoryInput.ShowDialog()
+        FrmInventoryInput.ShowDialog()
 
         Me.Enabled = True
 

--- a/InventoryManagementSystem/InventoryManagementSystem.vbproj
+++ b/InventoryManagementSystem/InventoryManagementSystem.vbproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Update="frmInventoryViewer.vb" />
+    <Compile Update="FrmInventoryViewer.vb" />
     <Compile Update="My Project\Application.Designer.vb">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>


### PR DESCRIPTION
- 参考 https://learn.microsoft.com/ja-jp/dotnet/standard/design-guidelines/naming-guidelines
  - 「ApplicationEvents.vb」は大文字始まりなのに「frm...」は小文字なのは何故？のような余計な混乱を回避する目的
  - 基本的にVisual Studioが自動的に推奨する指摘に則る
  - コントロール名もスコープはプロパティと同じなので大文字で始まるようにした（デザイナのデフォルトに合わせる）