### PR TITLE
簡単なシーケンス図の追加

### DIFF
--- a/task/在庫管理アプリの概要.md
+++ b/task/在庫管理アプリの概要.md
@@ -58,20 +58,21 @@ excelやgoogleスプレッドシートのような物をイメージしてもら
 - 終了ボタン
 この画面を消して、在庫入力を終了します。
 
+#### 在庫入力処理のシーケンス
 ```mermaid
 sequenceDiagram
 actor user as ユーザー
 participant app as アプリ
 participant db as データベース
-    user ->>+ app: 在庫入力, 追加
-    app ->> app: 「入力在庫」へ追加
-    app -->>- user: 結果確認
-    user ->>+ app: 在庫登録
-    app ->>+ db: 在庫データ登録
-    db -->>- app : 登録完了応答
+    user ->>+ app: 追加ボタン押下
+    app ->> app: 『入力在庫』へ追加
+    app -->>- user: 画面表示を更新
+    user ->>+ app: 登録ボタン押下
+    app ->>+ db: 『入力在庫』のデータを登録
+    db -->>- app : 登録完了の応答
     app ->>+ db: 在庫データ取得
-    db -->>- app : 取得結果応答
-    app -->>- user: 結果確認
+    db -->>- app : 取得結果の応答
+    app -->>- user: 画面表示を更新
 
 ```
 
@@ -92,15 +93,16 @@ participant db as データベース
 - 終了ボタン  
 この画面を消して、在庫確認を終了します。  
 
+#### 在庫検索処理のシーケンス
 ```mermaid
 sequenceDiagram
 actor user as ユーザー
 participant app as アプリ
 participant db as データベース
-    user ->>+ app: 在庫検索
+    user ->>+ app: 検索ボタン押下
     app ->>+ db: 在庫データ取得
-    db -->>- app : 取得結果応答
+    db -->>- app : 取得結果の応答
     app ->> app: 絞り込み
-    app -->>- user: 結果確認
+    app -->>- user: 画面表示を更新
 
 ```

--- a/task/在庫管理アプリの概要.md
+++ b/task/在庫管理アプリの概要.md
@@ -58,6 +58,23 @@ excelやgoogleスプレッドシートのような物をイメージしてもら
 - 終了ボタン
 この画面を消して、在庫入力を終了します。
 
+```mermaid
+sequenceDiagram
+actor user as ユーザー
+participant app as アプリ
+participant db as データベース
+    user ->>+ app: 在庫入力, 追加
+    app ->> app: 「入力在庫」へ追加
+    app -->>- user: 結果確認
+    user ->>+ app: 在庫登録
+    app ->>+ db: 在庫データ登録
+    db -->>- app : 登録完了応答
+    app ->>+ db: 在庫データ取得
+    db -->>- app : 取得結果応答
+    app -->>- user: 結果確認
+
+```
+
 ### 在庫確認画面  
 この画面も見えない所に在庫データ（以下『確認在庫』）を持っています。  
 この『確認在庫』をうまく成形して画面の下半分に表示している表（データグリッドビュー）に表示する内容を作っています。  
@@ -74,3 +91,16 @@ excelやgoogleスプレッドシートのような物をイメージしてもら
 
 - 終了ボタン  
 この画面を消して、在庫確認を終了します。  
+
+```mermaid
+sequenceDiagram
+actor user as ユーザー
+participant app as アプリ
+participant db as データベース
+    user ->>+ app: 在庫検索
+    app ->>+ db: 在庫データ取得
+    db -->>- app : 取得結果応答
+    app ->> app: 絞り込み
+    app -->>- user: 結果確認
+
+```


### PR DESCRIPTION
- github 上で見た場合に表示される簡単なシーケンス図を追加
  - 厳密には正確なシーケンス図ではないかもしれないが、理解のサポートができるかと
  - ローカル環境では`mermaid` をプレビューするための拡張機能が必要
    - Visual Studio Codeなら拡張機能あるけどVisual Studioにあるかどうか未確認 
- ブラウザ上では下のように見えます 
https://github.com/ToyamaDataCenter/InventSample2024/blob/add-uml/task/%E5%9C%A8%E5%BA%AB%E7%AE%A1%E7%90%86%E3%82%A2%E3%83%97%E3%83%AA%E3%81%AE%E6%A6%82%E8%A6%81.md